### PR TITLE
Small improvements for blender 4.0 support and the skeleton import.

### DIFF
--- a/mesh_geometry_utils.py
+++ b/mesh_geometry_utils.py
@@ -104,7 +104,11 @@ def join_geometries_with_matindex(geometries, matIndex):
         contextOverride = {}
         contextOverride["object"] = contextOverride["active_object"] = baseGeom.meshObj
         contextOverride["selected_objects"] = contextOverride["selected_editable_objects"] = [g.meshObj for g in geomsToJoin]
-        bpy.ops.object.join(contextOverride)
+        if (4, 00, 0) > bpy.app.version:
+            bpy.ops.object.join(contextOverride)
+        else:
+            with bpy.context.temp_override(**contextOverride):
+                bpy.ops.object.join()
 
     return baseGeom
 

--- a/skel_utils.py
+++ b/skel_utils.py
@@ -40,21 +40,24 @@ def apply_bone_data(boneData):
     
     if boneData.rotationQuat is not None:
         #rotMat = boneData.rotationQuat.to_matrix()
-#        boneData.rotationQuat = rotMat.inverted().transposed().to_quaternion()
+        #boneData.rotationQuat = rotMat.inverted().transposed().to_quaternion()
         #boneData.rotationQuat = boneData.rotationQuat.conjugated()
-        poseBone.rotation_quaternion.w = -boneData.rotationQuat.z
-        poseBone.rotation_quaternion.x = boneData.rotationQuat.y
-        poseBone.rotation_quaternion.y = -boneData.rotationQuat.x
-        poseBone.rotation_quaternion.z = -boneData.rotationQuat.w
+
+        # Blenders order is [x, y, z, w] but bone Data stores it [w, x, y, z] so we have to shift the values
+        poseBone.rotation_quaternion.w = boneData.rotationQuat.z
+        poseBone.rotation_quaternion.x = boneData.rotationQuat.w
+        poseBone.rotation_quaternion.y = boneData.rotationQuat.x
+        poseBone.rotation_quaternion.z = boneData.rotationQuat.y
         
         #poseBone.location = poseBone.rotation_quaternion @ poseBone.location
         
         #print("applied rotation {}".format(poseBone.rotation_quaternion))
 
     if boneData.location is not None:
-        poseBone.location.x = -boneData.location.x
-        poseBone.location.y = -boneData.location.y
-        poseBone.location.z = -boneData.location.z
+        # to make it clear: these are local offsets from the parent bone in local space coordinates
+        poseBone.location.x = boneData.location.x # x is the bone's forward axis and most offsets are applied here
+        poseBone.location.y = boneData.location.y
+        poseBone.location.z = boneData.location.z
         
         #print("LOC BEFORE QUAT MULT : {}".format(poseBone.location))
                 
@@ -68,6 +71,11 @@ def apply_bone_data(boneData):
         poseBone.scale.z = boneData.scale.z
         
     
+    # For some reason we have to mirror the bones on the x-z-plane. 
+    # I don't know why but we could reverse this for a potential skelton export
+    poseBone.location.y *= -1
+    poseBone.rotation_quaternion.x *=-1
+    poseBone.rotation_quaternion.z *=-1
     
     
         

--- a/skel_utils.py
+++ b/skel_utils.py
@@ -72,10 +72,10 @@ def apply_bone_data(boneData):
         
     
     # For some reason we have to mirror the bones on the x-z-plane. 
-    # I don't know why but we could reverse this for a potential skelton export
+    # I don't know why but we could reverse this for a potential skeleton export
     poseBone.location.y *= -1
-    poseBone.rotation_quaternion.x *=-1
-    poseBone.rotation_quaternion.z *=-1
+    poseBone.rotation_quaternion.x *= -1
+    poseBone.rotation_quaternion.z *= -1
     
     
         


### PR DESCRIPTION
There might be other areas which need an update for blender 4.0 - I just fixed the prominent one during import.

For the skeleton import I first reverted to the default values and then applied a mirror transform.
I'm not sure why this would be needed but maybe gta5 has such transforms or just the open format is using this - no idea, haven't checked.