### PR TITLE
Overall improvements to bring .mesh export on-par with OpenIV. Further improve skeleton import.

### DIFF
--- a/export_mesh.py
+++ b/export_mesh.py
@@ -171,6 +171,9 @@ def adjust_bone_weights(weights):
 
     return weights_adjusted
 
+def adjust_vertex_color(color):
+    return [int(colorvar*255) for colorvar in color]
+
 def write_verts_by_vertdeclaration(fileBuilder, geom, vertDeclaration):
     if vertDeclaration == 'S12D0183F':
         for i in range(len(geom.vertPositions)):
@@ -178,8 +181,8 @@ def write_verts_by_vertdeclaration(fileBuilder, geom, vertDeclaration):
                                                 parse_iterableFloatData(adjust_bone_weights(geom.boneWeights[i])),
                                                 parse_iterableData(geom.boneIndexes[i]),
                                                 parse_iterableFloatData(geom.vertNormals[i]),
-                                                parse_iterableIntData(geom.vColor[i]*255),
-                                                parse_iterableIntData(geom.vColor2[i]*255),
+                                                parse_iterableIntData(adjust_vertex_color(geom.vColor[i])),
+                                                parse_iterableIntData(adjust_vertex_color(geom.vColor2[i])),
                                                 parse_iterableFloatData(geom.uvCoords[i]),
                                                 parse_iterableFloatData(geom.uvCoords2[i]), #second UV map... not always used
                                                 parse_iterableFloatData(geom.qtangents[i])
@@ -190,8 +193,8 @@ def write_verts_by_vertdeclaration(fileBuilder, geom, vertDeclaration):
                                                 parse_iterableFloatData(adjust_bone_weights(geom.boneWeights[i])),
                                                 parse_iterableData(geom.boneIndexes[i]),
                                                 parse_iterableFloatData(geom.vertNormals[i]),
-                                                parse_iterableIntData(geom.vColor[i]*255),
-                                                parse_iterableIntData(geom.vColor2[i]*255),
+                                                parse_iterableIntData(adjust_vertex_color(geom.vColor[i])),
+                                                parse_iterableIntData(adjust_vertex_color(geom.vColor2[i])),
                                                 parse_iterableFloatData(geom.uvCoords[i]),
                                                 parse_iterableFloatData(geom.qtangents[i])
                                                 ])) 
@@ -201,8 +204,8 @@ def write_verts_by_vertdeclaration(fileBuilder, geom, vertDeclaration):
                                                 parse_iterableFloatData(adjust_bone_weights(geom.boneWeights[i])),
                                                 parse_iterableData(geom.boneIndexes[i]),
                                                 parse_iterableFloatData(geom.vertNormals[i]),
-                                                parse_iterableIntData(geom.vColor[i]*255),
-                                                parse_iterableIntData(geom.vColor2[i]*255),
+                                                parse_iterableIntData(adjust_vertex_color(geom.vColor[i])),
+                                                parse_iterableIntData(adjust_vertex_color(geom.vColor2[i])),
                                                 parse_iterableFloatData(geom.uvCoords[i])
                                                 ])) 
 

--- a/export_mesh.py
+++ b/export_mesh.py
@@ -78,6 +78,10 @@ def parse_iterableFloatData(iterable):
     """utility method for writing vectors and lists, limiting the precision of floats"""
     return " ".join(["{:.8f}".format(numvar) for numvar in iterable])
 
+def parse_iterableIntData(iterable):
+    """utility method for writing vectors and lists, limiting the precision to integers"""
+    return " ".join(["{:.0f}".format(numvar) for numvar in iterable])
+
 
 def parse_geometryDatas(geometryDatas, fileBuilder, vertexDeclarationType, startingShaderIndex=0):
     """adds formatted Bounds and Geometry data to the fileBuilder"""
@@ -132,39 +136,73 @@ def parse_geometryDatas(geometryDatas, fileBuilder, vertexDeclarationType, start
 
     fileBuilder.closeBracket()
 
+def adjust_bone_weights(weights):
+    """
+    GTA5 requires bone weights to be normalized and quantized in the 0-255 range. 
+    Otherwise it can happen that vertex positions become distorted. Especial for facial bones.
+    As weights are stored as floats in blender and the mesh file we have to adjust the float values
+    to be in sync with their integer counterpart.
+    """
+    wSum = sum(weights)
+    if wSum <= 0: return weights
+
+    # first normalize weights
+    # usually incoming weights are already normalised - but to be on the save side
+    Max = max(weights)
+    weights_normalised = [weight / wSum for weight in weights]
+
+    # convert to 0-255 range
+    weights_normalised_255 = [round(weight_normalised * 255) for weight_normalised in weights_normalised]
+
+    # fix normalisation by making sure the sum is always 255
+    wSum_255 = sum(weights_normalised_255)
+    wSumOffset = 255 - wSum_255
+    if wSumOffset != 0:
+        step = 1 if wSumOffset > 0 else -1
+        while wSumOffset != 0:
+            for idx in range(len(weights_normalised_255)):
+                if(weights_normalised_255[idx] > 0):
+                    weights_normalised_255[idx] += step
+                    wSumOffset -= step
+                if wSumOffset == 0: break
+
+    # convert back into 0-1 range
+    weights_adjusted = [weight_normalised_255 / 255 for weight_normalised_255 in weights_normalised_255]
+
+    return weights_adjusted
 
 def write_verts_by_vertdeclaration(fileBuilder, geom, vertDeclaration):
     if vertDeclaration == 'S12D0183F':
         for i in range(len(geom.vertPositions)):
             fileBuilder.writeLine(" / ".join([parse_iterableFloatData(geom.vertPositions[i]),
-                                                parse_iterableFloatData(geom.boneWeights[i]),
+                                                parse_iterableFloatData(adjust_bone_weights(geom.boneWeights[i])),
                                                 parse_iterableData(geom.boneIndexes[i]),
                                                 parse_iterableFloatData(geom.vertNormals[i]),
-                                                parse_iterableData([255] * 4), #vertex color? not sure about what this entry means
-                                                parse_iterableData([0] * 4), #no idea about this one either, but often it's all zeroes
+                                                parse_iterableIntData(geom.vColor[i]*255),
+                                                parse_iterableIntData(geom.vColor2[i]*255),
                                                 parse_iterableFloatData(geom.uvCoords[i]),
                                                 parse_iterableFloatData(geom.uvCoords2[i]), #second UV map... not always used
-                                                parse_iterableFloatData(geom.qtangents[i]) #this doesn't seem to be the qtangent, actually
+                                                parse_iterableFloatData(geom.qtangents[i])
                                                 ])) 
     elif vertDeclaration == 'SD7D22350':
         for i in range(len(geom.vertPositions)):
             fileBuilder.writeLine(" / ".join([parse_iterableFloatData(geom.vertPositions[i]),
-                                                parse_iterableFloatData(geom.boneWeights[i]),
+                                                parse_iterableFloatData(adjust_bone_weights(geom.boneWeights[i])),
                                                 parse_iterableData(geom.boneIndexes[i]),
                                                 parse_iterableFloatData(geom.vertNormals[i]),
-                                                parse_iterableData([255] * 4), #vertex color? not sure about what this entry means
-                                                parse_iterableData([0] * 4), #no idea about this one either, but often it's all zeroes
+                                                parse_iterableIntData(geom.vColor[i]*255),
+                                                parse_iterableIntData(geom.vColor2[i]*255),
                                                 parse_iterableFloatData(geom.uvCoords[i]),
-                                                parse_iterableFloatData(geom.qtangents[i]) #this doesn't seem to be the qtangent, actually
+                                                parse_iterableFloatData(geom.qtangents[i])
                                                 ])) 
     elif vertDeclaration == 'SBED48839':
         for i in range(len(geom.vertPositions)):
             fileBuilder.writeLine(" / ".join([parse_iterableFloatData(geom.vertPositions[i]),
-                                                parse_iterableFloatData(geom.boneWeights[i]),
+                                                parse_iterableFloatData(adjust_bone_weights(geom.boneWeights[i])),
                                                 parse_iterableData(geom.boneIndexes[i]),
                                                 parse_iterableFloatData(geom.vertNormals[i]),
-                                                parse_iterableData([255] * 4), #vertex color? not sure about what this entry means
-                                                parse_iterableData([0] * 4), #no idea about this one either, but often it's all zeroes
+                                                parse_iterableIntData(geom.vColor[i]*255),
+                                                parse_iterableIntData(geom.vColor2[i]*255),
                                                 parse_iterableFloatData(geom.uvCoords[i])
                                                 ])) 
 

--- a/import_mesh.py
+++ b/import_mesh.py
@@ -133,6 +133,12 @@ def parse_vert_dataline(line, geomData):
     lineDataEntry = lineData[3].strip().split(" ")
     geomData.vertNormals.append(Vector(map(float,lineDataEntry)))
     
+    #vertex colors
+    lineDataEntry = Vector(map(float, lineData[4].strip().split(" ")))
+    geomData.vColor.append(lineDataEntry)
+    lineDataEntry = Vector(map(float, lineData[5].strip().split(" ")))
+    geomData.vColor2.append(lineDataEntry)
+
     #uvs (they are flipped in the y axis!)
     lineDataEntry = Vector(map(float, lineData[6].strip().split(" ")))
     lineDataEntry.y *= -1

--- a/import_skel.py
+++ b/import_skel.py
@@ -4,6 +4,7 @@ import traceback
 from mathutils import *
 from . import reader_utils
 from . import skel_utils as skelutils
+from math import radians
 
 def import_skel_from_file(filepath):
     """returns an armature object if successful"""
@@ -64,6 +65,14 @@ def string_to_skel(reader, skelName):
     bpy.ops.pose.armature_apply()
     bpy.ops.object.mode_set(mode="OBJECT")
     print("Created skeleton {} successfully".format(skelName))
+
+    # we have to rotate the armature object to face the correct direction
+    armatureObj.rotation_euler = (0,0,radians(180))
+    bpy.ops.object.select_all(action='DESELECT')
+    bpy.context.view_layer.objects.active = armatureObj
+    armatureObj.select_set(True)
+    bpy.ops.object.transform_apply(location=False, rotation=True, scale=False)
+
     return armatureObj
     
 

--- a/mesh_geometry_datagather_utils.py
+++ b/mesh_geometry_datagather_utils.py
@@ -139,14 +139,14 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
                 vertBoneWeights.append(weight)
 
             #if this vert has less than 4 bones with weights, pad the indexes and weights lists with empty entries
-            vertBoneIndexes += [0] * (4 - len(vertBoneIndexes))
+            vertBoneIndexes += [1] * (4 - len(vertBoneIndexes))
             vertBoneWeights += [0.0] * (4 - len(vertBoneWeights))
 
             geom.boneIndexes.append(vertBoneIndexes)
             geom.boneWeights.append(vertBoneWeights)
 
         else:
-            geom.boneIndexes.append([0] * 4)
+            geom.boneIndexes.append([1] * 4)
             geom.boneWeights.append([0.0] * 4)
         
 
@@ -158,17 +158,33 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
         uvlayer = bm.loops.layers.uv[0]
         uvlayer2 = bm.loops.layers.uv[1]
 
+    #vertex color layers (should be two but who knows what people are doing)
+    vcLayer = None
+    vcLayer2 = None
+
+    if len(bm.loops.layers.color) > 0:
+        vcLayer = bm.loops.layers.color[0]
+
+        if len(bm.loops.layers.color) > 1:
+            vcLayer2 = bm.loops.layers.color[1]
+
     #fill uvCoords and qtangents with blank entries so that we can fill them in any order
-    geom.uvCoords = [(0.0, 0.0)] * len(geom.vertPositions)
-    geom.uvCoords2 = [(0.0, 0.0)] * len(geom.vertPositions)
+    geom.uvCoords = [(1.0, -1.0)] * len(geom.vertPositions)
+    geom.uvCoords2 = [(1.0, -1.0)] * len(geom.vertPositions)
+    geom.vColor = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
+    geom.vColor2 = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
     geom.qtangents = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
+
+    # tangents and bitangents
+    tangentsLayer = "tangents"
+    bitangentssignLayer = "bitangent_sign"
 
     #indices and uv
     for face in bm.faces:
         for vert in face.verts:
             geom.indices.append(vert.index)
         for loop in face.loops:
-            if geom.uvCoords[loop.vert.index] == (0.0, 0.0): #only parse this vert if we still don't have this data about it
+            if geom.uvCoords[loop.vert.index] == (1.0, -1.0): #only parse this vert if we still don't have this data about it
                 geom.uvCoords[loop.vert.index] = loop[uvlayer].uv.copy()
                 geom.uvCoords[loop.vert.index].y *= -1
                 
@@ -176,7 +192,11 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
                     geom.uvCoords2[loop.vert.index] = loop[uvlayer2].uv.copy()
                     geom.uvCoords2[loop.vert.index].y *= -1
 
-                geom.qtangents[loop.vert.index] = get_loop_qtangent(theMesh.loops[loop.index])
+                geom.vColor[loop.vert.index] = loop[vcLayer].copy()
+                if vcLayer2 is not None:
+                    geom.vColor2[loop.vert.index] = loop[vcLayer2].copy()
+
+                geom.qtangents[loop.vert.index] = get_loop_tangent(theMesh.loops[loop.index])
 
     #finally, calculate and store bounds
     geom.calculate_geometry_bounds()
@@ -185,7 +205,8 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
 
     return geom
 
-
+# This is not really what we need here. Keeping it here but if it is not needed elsewhere it could be deleted
+# Also haven't renamed "qtangents" into "tangents" throughout the code yet.
 def get_loop_qtangent(loop):
     """returns a quaternion containing combined tangent data from the target loop 
     (mesh.calc_tangents should already have been called!)"""
@@ -202,3 +223,7 @@ def get_loop_qtangent(loop):
     loopQuat = loopMatrix.to_quaternion()
 
     return list(reversed(loopQuat)) #apparently, the quaternion is stored as ZYXW instead of WXYZ in the .mesh file
+
+def get_loop_tangent(loop):
+    """the tangents data required for OpenIV"""
+    return list(loop.tangent) + [loop.bitangent_sign]

--- a/mesh_geometry_datagather_utils.py
+++ b/mesh_geometry_datagather_utils.py
@@ -172,7 +172,7 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
     #fill uvCoords and qtangents with blank entries so that we can fill them in any order
     geom.uvCoords = [(0.0, 0.0)] * len(geom.vertPositions)
     geom.uvCoords2 = [(0.0, 0.0)] * len(geom.vertPositions)
-    geom.vColor = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
+    geom.vColor = [(1.0, 1.0, 1.0, 1.0)] * len(geom.vertPositions)
     geom.vColor2 = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
     geom.qtangents = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
 

--- a/mesh_geometry_datagather_utils.py
+++ b/mesh_geometry_datagather_utils.py
@@ -61,8 +61,9 @@ def meshobj_to_geometries(meshObj, parentSkeleton):
     bpy.ops.object.mode_set( mode = 'OBJECT' )
 
     #limit weights to 4 per vertex and normalize them
-    bpy.ops.object.vertex_group_limit_total(group_select_mode='ALL', limit=4)
-    bpy.ops.object.vertex_group_normalize_all(group_select_mode='ALL', lock_active=False)
+    if(len(objCopy.vertex_groups) > 0):
+        bpy.ops.object.vertex_group_limit_total(group_select_mode='ALL', limit=4)
+        bpy.ops.object.vertex_group_normalize_all(group_select_mode='ALL', lock_active=False)
 
     #return to edit mode for the separation
     bpy.ops.object.mode_set( mode = 'EDIT' )
@@ -169,8 +170,8 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
             vcLayer2 = bm.loops.layers.color[1]
 
     #fill uvCoords and qtangents with blank entries so that we can fill them in any order
-    geom.uvCoords = [(1.0, -1.0)] * len(geom.vertPositions)
-    geom.uvCoords2 = [(1.0, -1.0)] * len(geom.vertPositions)
+    geom.uvCoords = [(0.0, 0.0)] * len(geom.vertPositions)
+    geom.uvCoords2 = [(0.0, 0.0)] * len(geom.vertPositions)
     geom.vColor = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
     geom.vColor2 = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
     geom.qtangents = [(0.0, 0.0, 0.0, 0.0)] * len(geom.vertPositions)
@@ -184,7 +185,7 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
         for vert in face.verts:
             geom.indices.append(vert.index)
         for loop in face.loops:
-            if geom.uvCoords[loop.vert.index] == (1.0, -1.0): #only parse this vert if we still don't have this data about it
+            if geom.uvCoords[loop.vert.index] == (0.0, 0.0): #only parse this vert if we still don't have this data about it
                 geom.uvCoords[loop.vert.index] = loop[uvlayer].uv.copy()
                 geom.uvCoords[loop.vert.index].y *= -1
                 
@@ -192,9 +193,10 @@ def parse_obj_to_geometrydata(meshObj, parentSkeleton, shaderIndex, correctedNor
                     geom.uvCoords2[loop.vert.index] = loop[uvlayer2].uv.copy()
                     geom.uvCoords2[loop.vert.index].y *= -1
 
-                geom.vColor[loop.vert.index] = loop[vcLayer].copy()
-                if vcLayer2 is not None:
-                    geom.vColor2[loop.vert.index] = loop[vcLayer2].copy()
+                if vcLayer is not None:
+                    geom.vColor[loop.vert.index] = loop[vcLayer].copy()
+                    if vcLayer2 is not None:
+                        geom.vColor2[loop.vert.index] = loop[vcLayer2].copy()
 
                 geom.qtangents[loop.vert.index] = get_loop_tangent(theMesh.loops[loop.index])
 

--- a/mesh_geometry_utils.py
+++ b/mesh_geometry_utils.py
@@ -38,6 +38,10 @@ def build_geometry(geometry, meshName):
 
     if len(geometry.uvCoords2) > 0:
         uvlayer2 = bm.loops.layers.uv.new('UVMap2')
+
+    # .. and vertex colour
+    vcLayer = bm.loops.layers.color.new('Color 1')
+    vcLayer2 = bm.loops.layers.color.new('Color 2')
     
     for face in addedFaces:
         for loop in face.loops:
@@ -45,6 +49,9 @@ def build_geometry(geometry, meshName):
             loop[uvlayer].uv = geometry.uvCoords[loop.vert.index]
             if uvlayer2 is not None:
                 loop[uvlayer2].uv = geometry.uvCoords2[loop.vert.index]
+            
+            loop[vcLayer] = geometry.vColor[loop.vert.index]
+            loop[vcLayer2] = geometry.vColor2[loop.vert.index]
         
     bm.faces.ensure_lookup_table()
 
@@ -139,10 +146,12 @@ class GeometryData():
         self.indices = [] #list of ints - vertex indices, in the winding order, in order to make faces
         self.uvCoords = [] #list of vectors (y axis is flipped, apparently)
         self.uvCoords2 = [] #list of vectors (y axis is flipped, apparently). Not necessarily used
+        self.vColor = [] # list of vertex colors from channel 1
+        self.vColor2 = [] # list of vertex colors from channel 2
         self.boneIndexes = [] #list of lists, each inner list having 4 ints
         self.boneWeights = [] #list of lists, each inner list having 4 floats
         self.bounds = None #dict with 'max' and 'min' vectors
-        self.qtangents = [] #list of quaternions, one per vertex, representing tangent space (for normal mapping)
+        self.qtangents = [] #list of tangents (x,y,z) and bitangents signs (w), one per vertex, representing tangent space (for normal mapping)
 
     def calculate_geometry_bounds(self):
         """fills this geometry's 'bounds' variable; also returns it"""

--- a/skel_utils.py
+++ b/skel_utils.py
@@ -39,46 +39,19 @@ def apply_bone_data(boneData):
     poseBone = boneData.poseBone
     
     if boneData.rotationQuat is not None:
-        #rotMat = boneData.rotationQuat.to_matrix()
-        #boneData.rotationQuat = rotMat.inverted().transposed().to_quaternion()
-        #boneData.rotationQuat = boneData.rotationQuat.conjugated()
-
         # Blenders order is [x, y, z, w] but bone Data stores it [w, x, y, z] so we have to shift the values
         poseBone.rotation_quaternion.w = boneData.rotationQuat.z
         poseBone.rotation_quaternion.x = boneData.rotationQuat.w
         poseBone.rotation_quaternion.y = boneData.rotationQuat.x
         poseBone.rotation_quaternion.z = boneData.rotationQuat.y
-        
-        #poseBone.location = poseBone.rotation_quaternion @ poseBone.location
-        
-        #print("applied rotation {}".format(poseBone.rotation_quaternion))
 
     if boneData.location is not None:
-        # to make it clear: these are local offsets from the parent bone in local space coordinates
+        # To make it clear: these are local offsets from the parent bone in local space coordinates
         poseBone.location.x = boneData.location.x # x is the bone's forward axis and most offsets are applied here
         poseBone.location.y = boneData.location.y
         poseBone.location.z = boneData.location.z
-        
-        #print("LOC BEFORE QUAT MULT : {}".format(poseBone.location))
-                
-        #print("applied location {}".format(poseBone.location))
-    if boneData.scale is not None:
-        if "SKEL_ROOT" in boneData.name:
-            poseBone.scale.x = -boneData.scale.x
-        else:
-            poseBone.scale.x = boneData.scale.x
-        poseBone.scale.y = boneData.scale.y
-        poseBone.scale.z = boneData.scale.z
-        
-    
-    # For some reason we have to mirror the bones on the x-z-plane. 
-    # I don't know why but we could reverse this for a potential skeleton export
-    poseBone.location.y *= -1
-    poseBone.rotation_quaternion.x *= -1
-    poseBone.rotation_quaternion.z *= -1
-    
-    
-        
+
+
 def create_armature(armatureName):
     """Creates an armature object and adds it to the current collection"""
     armature = bpy.data.armatures.new(armatureName)


### PR DESCRIPTION
General: Add vertex color support.
Import: Improve skeleton bone orientations, fix for incorrect secondary bone axis.
Export: Update tangent space support.
Export: Improve bone weights, fix for distorted vertex positions influenced by facial bones.
Export: Adjust unused uv and bone weight format to match OpenIV export.